### PR TITLE
fix: hero title overflow its block

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -701,10 +701,22 @@ a:focus, a:hover {
   font-weight: bold;
 }
 
++@media (max-width: 768px) {
+  .hero-area .block h2 {
+    font-size: 3.5em;
+  }
+}
+
 .hero-area .block p {
   color: #fff;
   margin-bottom: 20px;
   font-size: 30px;
+}
+
++@media (max-width: 768px) {
+  .hero-area .block p {
+    font-size: 20px;
+  }
 }
 
 .hero-area .block .list-inline {
@@ -2085,3 +2097,14 @@ code, kbd, pre, samp {
 .formations {
   padding-bottom: 50px;
 }
+
+.col-hero {
+  flex: 0 0 50%;
+  max-width: 25%;
+}
+
+.col-hero-title {
+  flex: 0 0 50%;
+  max-width: 75%;
+}
+

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -3,7 +3,7 @@
 <section class="hero-area">
     <div class="container">
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-hero">
                 <div class="video-player">
                 <!--
                   <img class="romainguichard" src="{{ with .Site.Params.hero.videoThumb }}{{.| absURL }}{{ end }}"
@@ -16,7 +16,7 @@
                     -->
                 </div>
             </div>
-            <div class="col-md-6">
+            <div class="col-hero-title">
                 <div class="block">
                     {{ with .Site.Params.hero.heading }}
                         <h2>{{ . }}</h2>


### PR DESCRIPTION
Hero title size is smaller for screen < 768px
Its adjacent block size is reduced down to 25% of the parent flex block